### PR TITLE
test: add autodownload

### DIFF
--- a/test/e2e/driver.spec.js
+++ b/test/e2e/driver.spec.js
@@ -10,6 +10,7 @@ const DEF_CAPS = {
   platformName: PLATFORM,
   browserName: 'chrome',
   'appium:automationName': 'Chromium',
+  'appium:autodownloadEnabled': true,
 };
 
 if (CHROME_BIN) {


### PR DESCRIPTION
since for example https://github.com/appium/appium-chromium-driver/pull/97 test failed as mismatched chromedriver version