### PR TITLE
feat: add mac as an option for platformNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ appium driver install chromium
 To start an automation session targeting this driver, construct a set of options/capabilities in
 any WebDriver client that (minimally) includes the following:
 
-|Capability|Value|
-|---|---|
-|`platformName`|One of `macOS`, `Linux`, or `Windows` (depending on your system|
-|`browserName`|`browserName` to the running WebDriver process. For example, `chrome` or `chromium` is for chromedriver, `MicrosoftEdge` or `msedge` is for msedge driver.|
-|`appium:automationName`|`Chromium`|
+|Capability| Value                                                                                                                                                      |
+|---|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|`platformName`| One of `macOS`, `mac`, `Linux`, or `Windows` (depending on your system                                                                                     |
+|`browserName`| `browserName` to the running WebDriver process. For example, `chrome` or `chromium` is for chromedriver, `MicrosoftEdge` or `msedge` is for msedge driver. |
+|`appium:automationName`| `Chromium`                                                                                                                                                 |
 
 Use these capabilities to start a new session. (Refer to the documentation for your WebDriver
 client for the particular syntax used to start a session in that client).

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ appium driver install chromium
 To start an automation session targeting this driver, construct a set of options/capabilities in
 any WebDriver client that (minimally) includes the following:
 
-|Capability| Value                                                                                                                                                      |
-|---|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|`platformName`| One of `macOS`, `mac`, `Linux`, or `Windows` (depending on your system                                                                                     |
-|`browserName`| `browserName` to the running WebDriver process. For example, `chrome` or `chromium` is for chromedriver, `MicrosoftEdge` or `msedge` is for msedge driver. |
-|`appium:automationName`| `Chromium`                                                                                                                                                 |
+|Capability|Value|
+|---|---|
+|`platformName`|One of `macOS`, `mac`, `Linux`, or `Windows` (depending on your system)|
+|`browserName`|`browserName` to the running WebDriver process. For example, `chrome` or `chromium` is for chromedriver, `MicrosoftEdge` or `msedge` is for msedge driver.|
+|`appium:automationName`|`Chromium`|
 
 Use these capabilities to start a new session. (Refer to the documentation for your WebDriver
 client for the particular syntax used to start a session in that client).

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "automationName": "Chromium",
     "platformNames": [
       "Windows",
+      "mac",
       "macOS",
       "Linux"
     ],


### PR DESCRIPTION
When I set the platformName in appium to macOS, it is converted to mac. The reason lies in the Platform enum class: `MAC("mac", "darwin", "macOS", "mac os x", "os x")`

So, I added the **mac** option to the list.

See also [https://github.com/appium/java-client/issues/1990](https://github.com/appium/java-client/issues/1990)
