### PR TITLE
test: fix import appium to make it work for nodejs 22.7 and existing ones

### DIFF
--- a/test/e2e/driver.spec.js
+++ b/test/e2e/driver.spec.js
@@ -1,9 +1,6 @@
-import appium from 'appium';
 import { waitForCondition } from 'asyncbox';
 import path from 'path';
 import {remote} from 'webdriverio';
-
-const {main: startAppium} = appium;
 
 const PLATFORM_ENV = process.env.TEST_PLATFORM || '';
 
@@ -73,10 +70,12 @@ describe('ChromeDriver', function() {
     chai = await import('chai');
     const chaiAsPromised = await import('chai-as-promised');
 
+    const appiumPkg = await import('appium')
+
     chai.should();
     chai.use(chaiAsPromised.default);
 
-    appium = await startAppium({port: PORT});
+    appium = await appiumPkg.main({port: PORT});
   });
 
   after(async function() {

--- a/test/e2e/driver.spec.js
+++ b/test/e2e/driver.spec.js
@@ -75,7 +75,7 @@ describe('ChromeDriver', function() {
     chai.should();
     chai.use(chaiAsPromised.default);
 
-    appium = await appiumPkg.main({port: PORT});
+    appium = await appiumPkg.default.main({port: PORT});
   });
 
   after(async function() {

--- a/test/e2e/driver.spec.js
+++ b/test/e2e/driver.spec.js
@@ -70,7 +70,7 @@ describe('ChromeDriver', function() {
     chai = await import('chai');
     const chaiAsPromised = await import('chai-as-promised');
 
-    const appiumPkg = await import('appium')
+    const appiumPkg = await import('appium');
 
     chai.should();
     chai.use(chaiAsPromised.default);

--- a/test/e2e/driver.spec.js
+++ b/test/e2e/driver.spec.js
@@ -1,7 +1,9 @@
-import {main as startAppium} from 'appium';
+import appium from 'appium';
 import { waitForCondition } from 'asyncbox';
 import path from 'path';
 import {remote} from 'webdriverio';
+
+const {main: startAppium} = appium;
 
 const PLATFORM_ENV = process.env.TEST_PLATFORM || '';
 


### PR DESCRIPTION
https://github.com/appium/appium-chromium-driver/actions/runs/10648661282/job/29517971174

```
(node:5988) [MODULE_TYPELESS_PACKAGE_JSON] Warning: file:///D:/a/appium-chromium-driver/appium-chromium-driver/test/e2e/driver.spec.js parsed as an ES module because module syntax was detected; to avoid the performance penalty of syntax detection, add "type": "module" to D:\a\appium-chromium-driver\appium-chromium-driver\package.json
(Use `node --trace-warnings ...` to show where the warning was created)

 Exception during run: file:///D:/a/appium-chromium-driver/appium-chromium-driver/test/e2e/driver.spec.js:1
import {main as startAppium} from 'appium';
        ^^^^
SyntaxError: Named export 'main' not found. The requested module 'appium' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'appium';
const {main: startAppium} = pkg;
```