### PR TITLE
feat: add install-chromedriver command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
       }
     },
     {
-      "files": "scripts/**/*",
+      "files": ["**/*.{mjs,cjs,js}"],
       "parserOptions": {"sourceType": "module"},
       "rules": {
         "@typescript-eslint/no-var-requires": "off"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,13 @@
       "rules": {
         "func-names": "off"
       }
+    },
+    {
+      "files": "scripts/**/*",
+      "parserOptions": {"sourceType": "module"},
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ this driver supports the following:
 > **Note**
 > `msedgedriver` support is limited. `appium:autodownloadEnabled` does not work for the driver, thus `appium:executable` is necessary to automate MSEdge browser properly.
 
+## Scripts
+
+### install-chromedriver
+
+This script is used to install the given or latest stable version of chromedriver from
+[Chorme for testing](https://github.com/GoogleChromeLabs/chrome-for-testing)
+with `appium driver run chromium install-chromedriver`.
+
+As same as [appium-chromedriver](https://github.com/appium/appium-chromedriver),
+`CHROMEDRIVER_VERSION` and `CHROMELABS_URL` environment variables are available.
+
+`CHROMEDRIVER_VERSION` lets the command download a specific chromedriver. i.e. `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`
+
+`CHROMELABS_URL` lets the command get the list of available chromedrivers from instead of the default `https://googlechromelabs.github.io`.
+
+
 ## Contributing
 
 Contributions to this project are welcome! Feel free to submit a PR on GitHub.

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ This script is used to install the given or latest stable version of chromedrive
 with `appium driver run chromium install-chromedriver`.
 
 Below environment arguments are available:
-- `CHROMEDRIVERS_EXECUTABLE_DIR`
+- `CHROMEDRIVER_EXECUTABLE_DIR`
   - Let the command to download chromedrivers in the given directory. Defaults to `node_modules/appium-chromedriver/chromedriver`.
-  - `CHROMEDRIVERS_EXECUTABLE_DIR=/Users/tmp/chromedrivers  appium driver run chromium install-chromedriver`
+  - `CHROMEDRIVER_EXECUTABLE_DIR=/Users/tmp/chromedrivers  appium driver run chromium install-chromedriver`
 - `CHROMEDRIVER_VERSION`
   - Let the command download a specific version.
   - i.e. `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ with `appium driver run chromium install-chromedriver`.
 
 Below environment arguments are available:
 - `CHROMEDRIVER_EXECUTABLE_DIR`
-  - Let the command to download chromedrivers in the given directory. Defaults to `node_modules/appium-chromedriver/chromedriver`.
-  - `CHROMEDRIVER_EXECUTABLE_DIR=/Users/tmp/chromedrivers  appium driver run chromium install-chromedriver`
+  - Let the command to download chromedrivers in the given directory. Once you set `appium:executableDir` to the same directory, a new session will refer to the same directory. Defaults to `node_modules/appium-chromedriver/chromedriver` in `appium-chromium-driver` package.
+  - `CHROMEDRIVER_EXECUTABLE_DIR=/tmp/chromedrivers  appium driver run chromium install-chromedriver`
 - `CHROMEDRIVER_VERSION`
   - Let the command download a specific version.
   - i.e. `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`

--- a/README.md
+++ b/README.md
@@ -84,14 +84,20 @@ this driver supports the following:
 This script is used to install the given or latest stable version of chromedriver (113+) from
 [Chrome for testing](https://github.com/GoogleChromeLabs/chrome-for-testing)
 with `appium driver run chromium install-chromedriver`.
+Please read [Version selection](https://developer.chrome.com/docs/chromedriver/downloads/version-selection) document
+to find a proper chromedriver manually that is good for your current browser.
 
 Below environment arguments are available:
 - `CHROMEDRIVER_EXECUTABLE_DIR`
-  - Let the command to download chromedrivers in the given directory. Once you set `appium:executableDir` to the same directory, a new session will refer to the same directory. Defaults to `node_modules/appium-chromedriver/chromedriver` in `appium-chromium-driver` package.
-  - `CHROMEDRIVER_EXECUTABLE_DIR=/tmp/chromedrivers  appium driver run chromium install-chromedriver`
+  - Let the command to download chromedrivers in the given directory. Defaults to `node_modules/appium-chromedriver/chromedriver` in `appium-chromium-driver` package.
+  - i.e.
+    - macOS/Linux: `CHROMEDRIVER_EXECUTABLE_DIR=/path/to/dir appium driver run chromium install-chromedriver`
+    - Windows: `$env:CHROMEDRIVER_EXECUTABLE_DIR='C:\path\to\folder'; appium driver run chromium install-chromedriver; Remove-Item Env:\CHROMEDRIVER_EXECUTABLE_DIR`
 - `CHROMEDRIVER_VERSION`
   - Let the command download a specific version.
-  - i.e. `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`
+  - i.e.
+    - macOS/Linux: `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`
+    - Windows: `$env:CHROMEDRIVER_VERSION='131.0.6778.3'; appium driver run chromium install-chromedriver; Remove-Item Env:\CHROMEDRIVER_VERSION`
 - `CHROMELABS_URL`
   - Let the command get the list of available chromedrivers from instead of the default `https://googlechromelabs.github.io`.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Below environment arguments are available:
     - macOS/Linux: `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`
     - Windows: `$env:CHROMEDRIVER_VERSION='131.0.6778.3'; appium driver run chromium install-chromedriver; Remove-Item Env:\CHROMEDRIVER_VERSION`
 - `CHROMELABS_URL`
-  - Let the command get the list of available chromedrivers from instead of the default `https://googlechromelabs.github.io`.
+  - Let the command get the list of available chromedrivers from the given mirror instead of the default one.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ this driver supports the following:
 
 This script is used to install the given or latest stable version of chromedriver from
 [Chorme for testing](https://github.com/GoogleChromeLabs/chrome-for-testing)
-with `appium driver run chromium install-chromedriver`.
+in `node_modules/appium-chromedriver/chromedriver` directory with `appium driver run chromium install-chromedriver`.
 
 As same as [appium-chromedriver](https://github.com/appium/appium-chromedriver),
 `CHROMEDRIVER_VERSION` and `CHROMELABS_URL` environment variables are available.

--- a/README.md
+++ b/README.md
@@ -81,17 +81,19 @@ this driver supports the following:
 
 ### install-chromedriver
 
-This script is used to install the given or latest stable version of chromedriver from
-[Chorme for testing](https://github.com/GoogleChromeLabs/chrome-for-testing)
-in `node_modules/appium-chromedriver/chromedriver` directory with `appium driver run chromium install-chromedriver`.
+This script is used to install the given or latest stable version of chromedriver (113+) from
+[Chrome for testing](https://github.com/GoogleChromeLabs/chrome-for-testing)
+with `appium driver run chromium install-chromedriver`.
 
-As same as [appium-chromedriver](https://github.com/appium/appium-chromedriver),
-`CHROMEDRIVER_VERSION` and `CHROMELABS_URL` environment variables are available.
-
-`CHROMEDRIVER_VERSION` lets the command download a specific chromedriver. i.e. `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`
-
-`CHROMELABS_URL` lets the command get the list of available chromedrivers from instead of the default `https://googlechromelabs.github.io`.
-
+Below environment arguments are available:
+- `CHROMEDRIVERS_EXECUTABLE_DIR`
+  - Let the command to download chromedrivers in the given directory. Defaults to `node_modules/appium-chromedriver/chromedriver`.
+  - `CHROMEDRIVERS_EXECUTABLE_DIR=/Users/tmp/chromedrivers  appium driver run chromium install-chromedriver`
+- `CHROMEDRIVER_VERSION`
+  - Let the command download a specific version.
+  - i.e. `CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver`
+- `CHROMELABS_URL`
+  - Let the command get the list of available chromedrivers from instead of the default `https://googlechromelabs.github.io`.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.55",
       "license": "Apache-2.0",
       "dependencies": {
-        "appium-chromedriver": "6.0.8",
+        "appium-chromedriver": "^6.0.8",
         "axios": "^1.6.5",
         "bluebird": "3.7.2",
         "lodash": "4.17.21"
@@ -5332,7 +5332,6 @@
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-6.0.8.tgz",
       "integrity": "sha512-TncJo4dsHAwu1UDCAJxcm/JjQ4Gf24fJKBgpPYOAsALFkV6F6mOruMRtb9Bxhs17akJnn2Gb4+3lnbj8U/55eg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@appium/base-driver": "^9.1.0",
         "@appium/support": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.55",
       "license": "Apache-2.0",
       "dependencies": {
-        "appium-chromedriver": "^6.0.8",
+        "appium-chromedriver": "^6.1.0",
         "axios": "^1.6.5",
         "bluebird": "3.7.2",
         "lodash": "4.17.21"
@@ -5329,9 +5329,9 @@
       }
     },
     "node_modules/appium-chromedriver": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-6.0.8.tgz",
-      "integrity": "sha512-TncJo4dsHAwu1UDCAJxcm/JjQ4Gf24fJKBgpPYOAsALFkV6F6mOruMRtb9Bxhs17akJnn2Gb4+3lnbj8U/55eg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-6.1.0.tgz",
+      "integrity": "sha512-mHOB3Dahuk3BDnXAf0AlwXhAzieVoO8b4Thx6GiNBNxklOqjyznViJYuQtT6GmEACIVZmZs1yjZ74rujltMXLw==",
       "dependencies": {
         "@appium/base-driver": "^9.1.0",
         "@appium/support": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -634,6 +634,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@appium/base-driver/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@appium/base-driver/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1468,6 +1479,18 @@
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@appium/base-plugin/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@appium/base-plugin/node_modules/brace-expansion": {
@@ -2342,6 +2365,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@appium/docutils/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@appium/docutils/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2749,16 +2784,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
-      }
-    },
-    "node_modules/@appium/support/node_modules/axios": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
-      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@appium/support/node_modules/type-fest": {
@@ -5918,6 +5943,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/appium-chromedriver/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/appium-chromedriver/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -6753,6 +6789,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/appium/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/appium/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -7357,11 +7405,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
+      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
+        "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-chromium-driver",
-  "version": "1.3.56",
+  "version": "1.3.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-chromium-driver",
-      "version": "1.3.56",
+      "version": "1.3.57",
       "license": "Apache-2.0",
       "dependencies": {
         "appium-chromedriver": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "appium-chromedriver": "^6.1.0",
-        "axios": "^1.6.5",
         "bluebird": "3.7.2",
         "lodash": "4.17.21"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "appium-chromium-driver",
-  "version": "1.3.54",
+  "version": "1.3.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-chromium-driver",
-      "version": "1.3.54",
+      "version": "1.3.55",
       "license": "Apache-2.0",
       "dependencies": {
         "appium-chromedriver": "6.0.8",
+        "axios": "^1.6.5",
         "bluebird": "3.7.2",
         "lodash": "4.17.21"
       },
@@ -632,17 +633,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@appium/base-driver/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@appium/base-driver/node_modules/brace-expansion": {
@@ -1479,18 +1469,6 @@
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@appium/base-plugin/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@appium/base-plugin/node_modules/brace-expansion": {
@@ -2365,18 +2343,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@appium/docutils/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@appium/docutils/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2784,6 +2750,16 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
+      }
+    },
+    "node_modules/@appium/support/node_modules/axios": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
+      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@appium/support/node_modules/type-fest": {
@@ -5944,17 +5920,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/appium-chromedriver/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/appium-chromedriver/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -6790,18 +6755,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/appium/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/appium/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -7406,11 +7359,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
-      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "appium-chromedriver": "^6.0.8",
+    "appium-chromedriver": "^6.1.0",
     "axios": "^1.6.5",
     "bluebird": "3.7.2",
     "lodash": "4.17.21"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "appium-chromedriver": "^6.1.0",
-    "axios": "^1.6.5",
     "bluebird": "3.7.2",
     "lodash": "4.17.21"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "appium-chromedriver": "6.0.8",
+    "appium-chromedriver": "^6.0.8",
     "axios": "^1.6.5",
     "bluebird": "3.7.2",
     "lodash": "4.17.21"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE",
-    "npm-shrinkwrap.json"
+    "npm-shrinkwrap.json",
+    "scripts/*.mjs"
   ],
   "scripts": {
     "build": "tsc -b",
@@ -57,6 +58,7 @@
   },
   "dependencies": {
     "appium-chromedriver": "6.0.8",
+    "axios": "^1.6.5",
     "bluebird": "3.7.2",
     "lodash": "4.17.21"
   },
@@ -80,7 +82,10 @@
       "macOS",
       "Linux"
     ],
-    "mainClass": "ChromiumDriver"
+    "mainClass": "ChromiumDriver",
+    "scripts": {
+      "install-chromedriver": "./scripts/install-chromedriver.mjs"
+    }
   },
   "typedoc": {
     "entryPoint": "./build/lib/index.js"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "CHANGELOG.md",
     "LICENSE",
     "npm-shrinkwrap.json",
-    "scripts/*.mjs"
+    "scripts"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -26,7 +26,7 @@ async function formatCdVersion (ver) {
       versions = (await axios({
         url,
         headers: {
-            'user-agent': 'appium',
+            'user-agent': 'appium-chromium-driver',
             accept: `application/json, */*`,
           },
         timeout: 15000,

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -22,10 +22,10 @@ async function formatCdVersion (ver) {
     if (_.toUpper(ver) !== VERSION_LATEST) {
       return ver;
     }
-    let jsonStr;
+    let versions;
     const url = `${getChromedriverUrl()}/chrome-for-testing/last-known-good-versions.json`;
     try {
-      jsonStr = (await axios({
+      versions = (await axios({
         url,
         headers: {
             'user-agent': 'appium',
@@ -33,20 +33,13 @@ async function formatCdVersion (ver) {
           },
         timeout: 15000,
         responseType: 'text',
-      })).data;
+      })).json;
     } catch (e) {
       throw new Error(`Cannot fetch the latest Chromedriver version. ` +
         `Make sure you can access ${url} from your machine or provide a mirror by setting ` +
         `a custom value to CHROMELABS_URL enironment variable. Original error: ${err.message}`);
     }
 
-    let json;
-    try {
-      json = JSON.parse(jsonStr);
-    } catch (e) {
-      const err = /** @type {Error} */ (e);
-      throw new Error(`Storage JSON cannot be parsed. Original error: ${err.message}`);
-    }
     /**
      * "timestamp":"2024-10-20T20:09:22.942Z",
      * "channels":{
@@ -56,10 +49,10 @@ async function formatCdVersion (ver) {
      *       "revision":"1356013"
      * ...
      */
-    if (!json?.channels?.Stable?.version) {
+    if (!versions?.channels?.Stable?.version) {
       throw new Error('The format of the storage JSON is not supported');
     }
-    return json.channels.Stable.version;
+    return versions.channels.Stable.version;
   }
 
 async function install () {

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -14,6 +14,10 @@ function getChromedriverVersion() {
         VERSION_LATEST;
 }
 
+function getExecutableDir() {
+  return process.env.CHROMEDRIVERS_EXECUTABLE_DIR || import.meta.dirname
+}
+
 async function formatCdVersion (ver) {
     if (_.toUpper(ver) !== VERSION_LATEST) {
       return ver;
@@ -60,7 +64,7 @@ async function formatCdVersion (ver) {
 
 async function install () {
   const client = new ChromedriverStorageClient({
-    chromedriverDir: import.meta.dirname,
+    chromedriverDir: getExecutableDir(),
   });
   await client.syncDrivers({
     versions: [await formatCdVersion(getChromedriverVersion())],

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -5,7 +5,7 @@ import axios from 'axios';
 const VERSION_LATEST = 'LATEST';
 
 function getChromedriverUrl() {
-    return process.env.CHROMELABS_URL || 'https://googlechromelabs.github.io'
+    return process.env.CHROMELABS_URL || 'https://googlechromelabs.github.io';
 }
 
 function getChromedriverVersion() {
@@ -13,7 +13,7 @@ function getChromedriverVersion() {
 }
 
 function getExecutableDir() {
-  return process.env.CHROMEDRIVER_EXECUTABLE_DIR || import.meta.dirname
+  return process.env.CHROMEDRIVER_EXECUTABLE_DIR || import.meta.dirname;
 }
 
 async function formatCdVersion (ver) {
@@ -35,7 +35,7 @@ async function formatCdVersion (ver) {
     } catch (e) {
       throw new Error(`Cannot fetch the latest Chromedriver version. ` +
         `Make sure you can access ${url} from your machine or provide a mirror by setting ` +
-        `a custom value to CHROMELABS_URL enironment variable. Original error: ${err.message}`);
+        `a custom value to CHROMELABS_URL enironment variable. Original error: ${e.message}`);
     }
 
     /**

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -1,64 +1,20 @@
-import _ from 'lodash';
 import { ChromedriverStorageClient } from 'appium-chromedriver';
-import axios from 'axios';
-
-const VERSION_LATEST = 'LATEST';
-
-function getChromedriverUrl() {
-    return process.env.CHROMELABS_URL || 'https://googlechromelabs.github.io';
-}
 
 function getChromedriverVersion() {
-    return process.env.CHROMEDRIVER_VERSION || VERSION_LATEST;
+    return process.env.CHROMEDRIVER_VERSION;
 }
 
 function getExecutableDir() {
   return process.env.CHROMEDRIVER_EXECUTABLE_DIR || import.meta.dirname;
 }
 
-async function formatCdVersion (ver) {
-    if (_.toUpper(ver) !== VERSION_LATEST) {
-      return ver;
-    }
-    let versions;
-    const url = `${getChromedriverUrl()}/chrome-for-testing/last-known-good-versions.json`;
-    try {
-      versions = (await axios({
-        url,
-        headers: {
-            'user-agent': 'appium-chromium-driver',
-            accept: `application/json, */*`,
-          },
-        timeout: 15000,
-        responseType: 'text',
-      })).json;
-    } catch (e) {
-      throw new Error(`Cannot fetch the latest Chromedriver version. ` +
-        `Make sure you can access ${url} from your machine or provide a mirror by setting ` +
-        `a custom value to CHROMELABS_URL enironment variable. Original error: ${e.message}`);
-    }
-
-    /**
-     * "timestamp":"2024-10-20T20:09:22.942Z",
-     * "channels":{
-     *    "Stable":{
-     *       "channel":"Stable",
-     *       "version":"130.0.6723.58",
-     *       "revision":"1356013"
-     * ...
-     */
-    if (!versions?.channels?.Stable?.version) {
-      throw new Error('The format of the storage JSON is not supported');
-    }
-    return versions.channels.Stable.version;
-  }
-
 async function install () {
   const client = new ChromedriverStorageClient({
     chromedriverDir: getExecutableDir(),
   });
+  const chromeDriverVersion = getChromedriverVersion() || await client.getLatestKnownGoodVersion();
   await client.syncDrivers({
-    versions: [await formatCdVersion(getChromedriverVersion())],
+    versions: [chromeDriverVersion],
   });
 }
 

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -5,7 +5,7 @@ function getChromedriverVersion() {
 }
 
 function getExecutableDir() {
-  return process.env.CHROMEDRIVER_EXECUTABLE_DIR || import.meta.dirname;
+  return process.env.CHROMEDRIVER_EXECUTABLE_DIR;
 }
 
 async function install () {

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -15,7 +15,7 @@ function getChromedriverVersion() {
 }
 
 function getExecutableDir() {
-  return process.env.CHROMEDRIVERS_EXECUTABLE_DIR || import.meta.dirname
+  return process.env.CHROMEDRIVER_EXECUTABLE_DIR || import.meta.dirname
 }
 
 async function formatCdVersion (ver) {

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -1,0 +1,70 @@
+import _ from 'lodash';
+import { ChromedriverStorageClient } from 'appium-chromedriver';
+import axios from 'axios';
+
+const VERSION_LATEST = 'LATEST';
+
+function getChromedriverUrl() {
+    return process.env.CHROMELABS_URL || 'https://googlechromelabs.github.io'
+}
+
+function getChromedriverVersion() {
+    return process.env.npm_config_chromedriver_version ||
+        process.env.CHROMEDRIVER_VERSION ||
+        VERSION_LATEST;
+}
+
+async function formatCdVersion (ver) {
+    if (_.toUpper(ver) !== VERSION_LATEST) {
+      return ver;
+    }
+    let jsonStr;
+    const url = `${getChromedriverUrl()}/chrome-for-testing/last-known-good-versions.json`;
+    try {
+      jsonStr = (await axios({
+        url,
+        headers: {
+            'user-agent': 'appium',
+            accept: `application/json, */*`,
+          },
+        timeout: 15000,
+        responseType: 'text',
+      })).data;
+    } catch (e) {
+      throw new Error(`Cannot fetch the latest Chromedriver version. ` +
+        `Make sure you can access ${url} from your machine or provide a mirror by setting ` +
+        `a custom value to CHROMELABS_URL enironment variable. Original error: ${err.message}`);
+    }
+
+    let json;
+    try {
+      json = JSON.parse(jsonStr);
+    } catch (e) {
+      const err = /** @type {Error} */ (e);
+      throw new Error(`Storage JSON cannot be parsed. Original error: ${err.message}`);
+    }
+    /**
+     * "timestamp":"2024-10-20T20:09:22.942Z",
+     * "channels":{
+     *    "Stable":{
+     *       "channel":"Stable",
+     *       "version":"130.0.6723.58",
+     *       "revision":"1356013"
+     * ...
+     */
+    if (!json?.channels?.Stable?.version) {
+      throw new Error('The format of the storage JSON is not supported');
+    }
+    return json.channels.Stable.version;
+  }
+
+async function install () {
+  const client = new ChromedriverStorageClient({
+    chromedriverDir: import.meta.dirname,
+  });
+  await client.syncDrivers({
+    versions: [await formatCdVersion(getChromedriverVersion())],
+  });
+}
+
+(async () => await install())();

--- a/scripts/install-chromedriver.mjs
+++ b/scripts/install-chromedriver.mjs
@@ -9,9 +9,7 @@ function getChromedriverUrl() {
 }
 
 function getChromedriverVersion() {
-    return process.env.npm_config_chromedriver_version ||
-        process.env.CHROMEDRIVER_VERSION ||
-        VERSION_LATEST;
+    return process.env.CHROMEDRIVER_VERSION || VERSION_LATEST;
 }
 
 function getExecutableDir() {


### PR DESCRIPTION
Let's add the same automatic download (latest one) which is removed from appium-chromedriver.

This command will give the below log's ability.

```
kazu $ appium driver run chromium install-chromedriver
WARN Appium Appium encountered 1 warning while validating drivers found in manifest /Users/kazu/github/appium-chromium-driver/node_modules/.cache/appium/extensions.yaml
WARN Appium Driver "chromium" has 1 potential problem: 
WARN Appium   - Driver "chromium" (package `appium-chromium-driver`) may be incompatible with the current version of Appium (v2.6.0) due to its peer dependency on Appium ^2.11.5. Please install a compatible version of the driver.
dbug ChromedriverGoogleapisStorageClient Parsed 776 entries from storage XML
info ChromedriverGoogleapisStorageClient The total count of entries in the mapping: 546
info ChromedriverChromelabsStorageClient The total count of entries in the mapping: 4975
dbug ChromedriverStorageClient Selecting chromedrivers whose versions match to 130.0.6723.58
dbug ChromedriverStorageClient Got 5 items
dbug ChromedriverStorageClient Selecting chromedrivers whose platform matches to mac:arm64
dbug ChromedriverStorageClient Got 1 item
dbug ChromedriverStorageClient Excluding older patches if present
dbug ChromedriverStorageClient Versions mapping: {
dbug ChromedriverStorageClient   "130": [
dbug ChromedriverStorageClient     "130.0.6723.58"
dbug ChromedriverStorageClient   ]
dbug ChromedriverStorageClient }
dbug ChromedriverStorageClient Got 1 driver to sync: [
dbug ChromedriverStorageClient   "130.0.6723.58/chromedriver-mac-arm64.zip"
dbug ChromedriverStorageClient ]
dbug ChromedriverStorageClient Retrieving 'https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.58/mac-arm64/chromedriver-mac-arm64.zip' to '/var/folders/l5/4djs4rts6dg8jxwjv45wkr_w0000gn/T/2024920-54661-1rq3y7o.td0k/0.zip'
dbug Support Traversed 2 directories and 3 files in 2ms
dbug ChromedriverStorageClient Moving the extracted 'chromedriver' to '/Users/kazu/github/appium-chromium-driver/node_modules/appium-chromedriver/chromedriver/mac/chromedriver-mac-arm64_v130.0.6723.58'
dbug ChromedriverStorageClient Permissions of the file '/Users/kazu/github/appium-chromium-driver/node_modules/appium-chromedriver/chromedriver/mac/chromedriver-mac-arm64_v130.0.6723.58' have been changed to 755
info ChromedriverStorageClient Successfully synchronized 1 chromedriver
✔ install-chromedriver successfully ran
```
```                               
kazu $ CHROMEDRIVER_VERSION=131.0.6778.3 appium driver run chromium install-chromedriver
WARN Appium Appium encountered 1 warning while validating drivers found in manifest /Users/kazu/github/appium-chromium-driver/node_modules/.cache/appium/extensions.yaml
WARN Appium Driver "chromium" has 1 potential problem: 
WARN Appium   - Driver "chromium" (package `appium-chromium-driver`) may be incompatible with the current version of Appium (v2.6.0) due to its peer dependency on Appium ^2.11.5. Please install a compatible version of the driver.
dbug ChromedriverGoogleapisStorageClient Parsed 776 entries from storage XML
info ChromedriverGoogleapisStorageClient The total count of entries in the mapping: 546
info ChromedriverChromelabsStorageClient The total count of entries in the mapping: 4975
dbug ChromedriverStorageClient Selecting chromedrivers whose versions match to 131.0.6778.3
dbug ChromedriverStorageClient Got 5 items
dbug ChromedriverStorageClient Selecting chromedrivers whose platform matches to mac:arm64
dbug ChromedriverStorageClient Got 1 item
dbug ChromedriverStorageClient Excluding older patches if present
dbug ChromedriverStorageClient Versions mapping: {
dbug ChromedriverStorageClient   "131": [
dbug ChromedriverStorageClient     "131.0.6778.3"
dbug ChromedriverStorageClient   ]
dbug ChromedriverStorageClient }
dbug ChromedriverStorageClient Got 1 driver to sync: [
dbug ChromedriverStorageClient   "131.0.6778.3/chromedriver-mac-arm64.zip"
dbug ChromedriverStorageClient ]
dbug ChromedriverStorageClient Retrieving 'https://storage.googleapis.com/chrome-for-testing-public/131.0.6778.3/mac-arm64/chromedriver-mac-arm64.zip' to '/var/folders/l5/4djs4rts6dg8jxwjv45wkr_w0000gn/T/2024920-54819-14lyp1m.o995/0.zip'
dbug Support Traversed 2 directories and 3 files in 1ms
dbug ChromedriverStorageClient Moving the extracted 'chromedriver' to '/Users/kazu/github/appium-chromium-driver/node_modules/appium-chromedriver/chromedriver/mac/chromedriver-mac-arm64_v131.0.6778.3'
dbug ChromedriverStorageClient Permissions of the file '/Users/kazu/github/appium-chromium-driver/node_modules/appium-chromedriver/chromedriver/mac/chromedriver-mac-arm64_v131.0.6778.3' have been changed to 755
info ChromedriverStorageClient Successfully synchronized 1 chromedriver
✔ install-chromedriver successfully ran
kazu $ ls /Users/kazu/github/appium-chromium-driver/node_modules/appium-chromedriver/chromedriver/mac/
chromedriver-mac-arm64_v130.0.6723.58 chromedriver-mac-arm64_v131.0.6778.3
```

https://github.com/appium/appium-chromium-driver/issues/363