### PR TITLE
feat: Update server compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Configure Appium Server
         shell: bash
         run: |
-          npm install -g appium@rc
+          appium_ver=$(node -p "require('./package.json').peerDependencies?.appium")
+          npm install -g "appium@$appium_ver"
           cwd=$(pwd)
           pushd "$cwd"
           cd ~

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,7 @@ jobs:
         id: setup-chrome
       - name: Configure Chrome
         shell: bash
-        run: |
-          "${{ steps.setup-chrome.outputs.chrome-path }}" --version
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+        run: echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
       - name: Start Display
         if: ${{ runner.os != 'Windows' }}
         run: DISPLAY=:99 sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: ${{ fromJSON(needs.prepare_matrix.outputs.versions) }}
-    env:
-      TEST_PORT: 4567
     name: Tests
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Configure Chrome
         shell: bash
         run: |
-          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+          "${{ steps.setup-chrome.outputs.chrome-path }}" --version
           echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
       - name: Start Display
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,29 +53,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Appium
-        run: npm install -g appium@rc
       - name: Install dependencies
         run: npm install
-      - name: Start Server
+      - name: Configure Appium Server
         shell: bash
         run: |
+          npm install -g appium@rc
           cwd=$(pwd)
           pushd "$cwd"
           cd ~
           appium driver install --source=local "$cwd"
-          nohup appium server \
-            --port=$TEST_PORT \
-            --relaxed-security \
-            --log-no-colors \
-            --log-timestamp \
-            2>&1 > "$cwd/appium.log" &
-          sleep 5
           popd
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@latest
       - name: Print Chrome version
+        if: ${{ runner.os != 'macOS' }}
         run: chrome --version
+      - name: Print Chrome version (mac)
+        if: ${{ runner.os == 'macOS' }}
+        run: chromium --version
       - name: Start Display
         if: ${{ runner.os != 'Windows' }}
         run: DISPLAY=:99 sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
@@ -87,12 +83,6 @@ jobs:
           else
             DISPLAY=:99 TEST_PLATFORM="${{ runner.os }}" npm run test:ci
           fi
-      - name: Save server output
-        if: ${{ always() }}
-        uses: actions/upload-artifact@master
-        with:
-          name: appium-${{ matrix.os }}-${{ matrix.node-version }}
-          path: appium.log
 
   release:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,7 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@latest
       - name: Print Chrome version
-        if: ${{ runner.os != 'macOS' }}
         run: chrome --version
-      - name: Print Chrome version (mac)
-        if: ${{ runner.os == 'macOS' }}
-        run: chromium --version
       - name: Start Display
         if: ${{ runner.os != 'Windows' }}
         run: DISPLAY=:99 sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,12 @@ jobs:
           popd
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@latest
-      - name: Print Chrome version
-        run: chrome --version
+        id: setup-chrome
+      - name: Configure Chrome
+        shell: bash
+        run: |
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
+          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
       - name: Start Display
         if: ${{ runner.os != 'Windows' }}
         run: DISPLAY=:99 sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         run: npm install
       - name: ESLint
         run: npm run lint
+
   test:
     needs:
     - lint
@@ -40,6 +41,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: ${{ fromJSON(needs.prepare_matrix.outputs.versions) }}
+    env:
+      TEST_PORT: 4567
     name: Tests
     permissions:
       contents: read
@@ -50,32 +53,47 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Appium
+        run: npm install -g appium@rc
       - name: Install dependencies
         run: npm install
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@latest
-      - name: Print Chrome version
-        if: ${{ runner.os != 'macOS' }}
-        run: chrome --version
-      - name: Print Chrome version (mac)
-        if: ${{ runner.os == 'macOS' }}
-        run: chromium --version
-      - name: Start Display
+      - name: Start Server
         shell: bash
         run: |
-          if ["$RUNNER_OS" == "Windows"]; then
-            echo "Not starting display since on Windows"
-          else
-            DISPLAY=:99 sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          fi
+          cwd=$(pwd)
+          pushd "$cwd"
+          cd ~
+          appium driver install --source=local "$cwd"
+          nohup appium server \
+            --port=$TEST_PORT \
+            --relaxed-security \
+            --log-no-colors \
+            --log-timestamp \
+            2>&1 > "$cwd/appium.log" &
+          sleep 5
+          popd
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+      - name: Print Chrome version
+        run: chrome --version
+      - name: Start Display
+        if: ${{ runner.os != 'Windows' }}
+        run: DISPLAY=:99 sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
       - name: Run smoke, unit & E2E tests
         shell: bash
         run: |
-          if ["$RUNNER_OS" == "Windows"]; then
-            TEST_PLATFORM="$RUNNER_OS" npm run test:ci
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            TEST_PLATFORM="${{ runner.os }}" npm run test:ci
           else
-            DISPLAY=:99 TEST_PLATFORM="$RUNNER_OS" npm run test:ci
+            DISPLAY=:99 TEST_PLATFORM="${{ runner.os }}" npm run test:ci
           fi
+      - name: Save server output
+        if: ${{ always() }}
+        uses: actions/upload-artifact@master
+        with:
+          name: appium-${{ matrix.os }}-${{ matrix.node-version }}
+          path: appium.log
+
   release:
     if: github.ref == 'refs/heads/main'
     needs: test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is an [Appium](https://github.com/appium/appium) driver for Chromium-based 
 Chrome).
 
 > [!IMPORTANT]
-> Since major version *2.0.0* this driver is only compatible to Appium 3
+> Since major version *2.0.0*, this driver is only compatible with Appium 3.
 
 ### Why does this project exist?
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 This is an [Appium](https://github.com/appium/appium) driver for Chromium-based browsers (like
 Chrome).
 
+> [!IMPORTANT]
+> Since major version *2.0.0* this driver is only compatible to Appium 3
+
 ### Why does this project exist?
 
 It is already possible to automate Chromium browsers with

--- a/package.json
+++ b/package.json
@@ -57,16 +57,16 @@
     "singleQuote": true
   },
   "dependencies": {
-    "appium-chromedriver": "^7.0.6",
+    "appium-chromedriver": "^8.0.0",
     "bluebird": "^3.7.2",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "appium": "^2.11.5"
+    "appium": "^3.0.0-rc.2"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "publishConfig": {
     "access": "public"
@@ -91,9 +91,9 @@
   },
   "types": "./build/lib/driver.d.ts",
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.42",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10
BREAKING CHANGE: Required Appium server version has been bumped to >=3.0.0-rc.2
