### PR TITLE
fix: prevent caps warning messages

### DIFF
--- a/lib/desired-caps.ts
+++ b/lib/desired-caps.ts
@@ -28,12 +28,6 @@ export const desiredCapConstraints = {
   browserName: {
     isString: true,
   },
-  chromeOptions: {
-    isObject: true,
-  },
-  edgeOptions: {
-    isObject: true,
-  },
 } as const satisfies Constraints;
 
 export type CDConstraints = typeof desiredCapConstraints;

--- a/lib/desired-caps.ts
+++ b/lib/desired-caps.ts
@@ -28,6 +28,12 @@ export const desiredCapConstraints = {
   browserName: {
     isString: true,
   },
+  chromeOptions: {
+    isObject: true,
+  },
+  edgeOptions: {
+    isObject: true,
+  },
 } as const satisfies Constraints;
 
 export type CDConstraints = typeof desiredCapConstraints;

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -57,27 +57,6 @@ export class ChromiumDriver
     return this._cd;
   }
 
-  /**
-   * Exclude browser-specific capabilities (e.g. `goog:chromeOptions` and `ms:edgeOptions`)
-   * from the capabilities to skip validation error for unrecognized capabilities.
-   * @param caps
-   * @returns
-   */
-  private excludeBrowserPrefixCaps(caps: Record<string, any>): Record<string, any> {
-    const browserCapKeys = Object.keys(caps).filter(
-      (key) => key.startsWith(CHROME_VENDOR_PREFIX) || key.startsWith(EDGE_VENDOR_PREFIX),
-    );
-    return Object.keys(caps).reduce(
-      (acc, capName) => {
-        if (!browserCapKeys.includes(capName)) {
-          acc[capName] = caps[capName];
-        }
-        return acc;
-      },
-      {} as Record<string, any>,
-    );
-  }
-
   override validateDesiredCaps(caps: any): caps is ChromiumDriverCaps {
     return super.validateDesiredCaps(this.excludeBrowserPrefixCaps(caps));
   }
@@ -99,6 +78,27 @@ export class ChromiumDriver
       this._bidiProxyUrl = String(returnedCaps.webSocketUrl);
     }
     return [sessionId, returnedCaps];
+  }
+
+  /**
+   * Exclude browser-specific capabilities (e.g. `goog:chromeOptions` and `ms:edgeOptions`)
+   * from the capabilities to skip validation error for unrecognized capabilities.
+   * @param caps
+   * @returns
+   */
+  private excludeBrowserPrefixCaps(caps: Record<string, any>): Record<string, any> {
+    const browserCapKeys = Object.keys(caps).filter(
+      (key) => key.startsWith(CHROME_VENDOR_PREFIX) || key.startsWith(EDGE_VENDOR_PREFIX),
+    );
+    return Object.keys(caps).reduce(
+      (acc, capName) => {
+        if (!browserCapKeys.includes(capName)) {
+          acc[capName] = caps[capName];
+        }
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
   }
 
   private async getBrowserInfo(): Promise<BrowserInfo | undefined> {

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -65,15 +65,17 @@ export class ChromiumDriver
    */
   private excludeBrowserPrefixCaps(caps: Record<string, any>): Record<string, any> {
     const browserCapKeys = Object.keys(caps).filter(
-      (key) =>
-        key.startsWith(CHROME_VENDOR_PREFIX) || key.startsWith(EDGE_VENDOR_PREFIX),
+      (key) => key.startsWith(CHROME_VENDOR_PREFIX) || key.startsWith(EDGE_VENDOR_PREFIX),
     );
-    return Object.keys(caps).reduce((acc, capName) => {
-      if (!browserCapKeys.includes(capName)) {
-        acc[capName] = caps[capName];
-      }
-      return acc;
-    }, {} as Record<string, any>);
+    return Object.keys(caps).reduce(
+      (acc, capName) => {
+        if (!browserCapKeys.includes(capName)) {
+          acc[capName] = caps[capName];
+        }
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
   }
 
   override validateDesiredCaps(caps: any): caps is ChromiumDriverCaps {

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -57,6 +57,29 @@ export class ChromiumDriver
     return this._cd;
   }
 
+  /**
+   * Exclude browser-specific capabilities (e.g. `goog:chromeOptions` and `ms:edgeOptions`)
+   * from the capabilities to skip validation error for unrecognized capabilities.
+   * @param caps
+   * @returns
+   */
+  private excludeBrowserPrefixCaps(caps: Record<string, any>): Record<string, any> {
+    const browserCapKeys = Object.keys(caps).filter(
+      (key) =>
+        key.startsWith(CHROME_VENDOR_PREFIX) || key.startsWith(EDGE_VENDOR_PREFIX),
+    );
+    return Object.keys(caps).reduce((acc, capName) => {
+      if (!browserCapKeys.includes(capName)) {
+        acc[capName] = caps[capName];
+      }
+      return acc;
+    }, {} as Record<string, any>);
+  }
+
+  override validateDesiredCaps(caps: any): caps is ChromiumDriverCaps {
+    return super.validateDesiredCaps(this.excludeBrowserPrefixCaps(caps));
+  }
+
   override async createSession(
     jsonwpDesiredCapabilities: W3CChromiumDriverCaps,
     jsonwpRequiredCaps?: W3CChromiumDriverCaps,


### PR DESCRIPTION
Closes https://github.com/appium/appium-chromium-driver/issues/430

The current validation message shows a warning for the goog/ms options. This will prevent the error message.
```
[ChromiumDriver@6ec4] The following provided capabilities were not recognized by this driver:
[ChromiumDriver@6ec4]   goog:chromeOptions
[ChromiumDriver@6ec4]   unhandledPromptBehavior
```

We can let the underlying driver handle them - if they are valid or not.

https://github.com/appium/appium-chromium-driver/actions/runs/25040872511 is the test result