### PR TITLE
ci: fix workflow branch name

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,14 +2,14 @@ name: Build Docs
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'package*.json'
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/build-docs.yml' # this file
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'package*.json'
       - 'docs/**'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,13 +1,13 @@
 name: Lint and Unit Tests
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '*.md'
     - 'mkdocs.yml'
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - 'docs/**'
     - '*.md'


### PR DESCRIPTION
Follow-up to #443.
I had copied the CI changes from the geckodriver repo, which uses `master`, while this repo uses `main`.