### PR TITLE
docs: tune capabilities & other pages

### DIFF
--- a/docs/guides/other-browsers.md
+++ b/docs/guides/other-browsers.md
@@ -15,8 +15,8 @@ and Edge.
 Usually, no configuration is required in the browser itself. The main differences from regular
 Chrome/Edge are in the required capabilities:
 
-* The target browser must be specified by customizing the path to the browser binary, using the [`goog:chromeOptions`](../reference/capabilities.md#google-specific) capability
-* Most browsers will require the [`appium:executable`](../reference/capabilities.md#appium-specific) capability in order to specify a compatible `chromedriver` binary
+* The target browser must be specified by customizing the path to the browser binary, using the [`goog:chromeOptions`](../reference/capabilities.md#chromeoptions) capability
+* Most browsers will require the [`appium:executable`](../reference/capabilities.md#executable) capability in order to specify a compatible `chromedriver` binary
     * The browser's Chromium version can usually be found in its About page. You can then download a compatible `chromedriver` binary either manually or using the [`install-chromedriver`](../reference/scripts.md) driver script. Note that there may not always be a binary with the exact same version as Chromium, but the closest match should still work.
 
 ### Background

--- a/docs/reference/bidi.md
+++ b/docs/reference/bidi.md
@@ -2,12 +2,12 @@
 hide:
   - toc
 
-title: BiDi Events
+title: BiDi Commands and Events
 ---
 
 The Chromium driver has partial support of the [WebDriver BiDi Protocol](https://w3c.github.io/webdriver-bidi/)
 since version 1.3.0.
 
-All supported BiDi events are inherited from the Appium base driver, and can
-be found in [their Appium docs reference page](https://appium.io/docs/en/latest/reference/api/bidi/).
-The driver does not define any additional events.
+All supported BiDi commands and events are inherited from the Appium base driver, and can be found
+in [their Appium docs reference page](https://appium.io/docs/en/latest/reference/api/bidi/).
+The driver does not define any additional commands or events.

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -10,33 +10,128 @@ For other capabilities recognized by the Appium server, see
 
 ## Standard
 
-| Capability | Description |
-| --- | --- |
-| `platformName` | Must be set to `mac`, `linux` or `windows` |
-| `browserName` | Must be set to `MicrosoftEdge` if automating MS Edge. Automatically set to `chrome` if omitted |
+Refer to [the W3C WebDriver documentation](https://w3c.github.io/webdriver/#capabilities)
+for more information about these capabilities.
 
-## Appium-Specific
+### platformName
 
-| <div style="width:14em">Capability</div> | Description | Default |
-| --- | --- | --- |
-| `appium:automationName` | Must be set to `Chromium` | |
-| `appium:chromedriverPort` | The port to use for starting `chromedriver`/`msedgedriver` | 9515 |
-| `appium:executable` | Custom path to a `chromedriver`/`msedgedriver` binary | |
-| `appium:executableDir` | Custom path to a directory containing `chromedriver`/`msedgedriver` binaries | |
-| `appium:verbose` | Whether to add the `--verbose` flag when launching `chromedriver`/`msedgedriver` | false |
-| `appium:logPath` | Value of the `--log-path` parameter provided to `chromedriver`/`msedgedriver` | |
-| `appium:disableBuildCheck` | Whether to add the `--disable-build-check` flag when launching `chromedriver`/`msedgedriver` | false |
-| `appium:autodownloadEnabled` | Whether to automatically download a compatible `chromedriver`/`msedgedriver` when starting a session | true |
-| `appium:useSystemExecutable` | Whether to use the `chromedriver` binary bundled with Chromium driver. Primarily relevant for Chromium driver versions 1.3.35 or earlier, which automatically downloaded `chromedriver` upon installation. | false |
+| Name | Type | Default |
+| -- | -- | -- |
+| `platformName` | `string` | Not specified |
 
-## Google-Specific
+This capability be set to `mac`, `linux` or `windows` (case-insensitive)
 
-| <div style="width:10em">Capability</div> | Description |
-| --- | --- |
-| `goog:chromeOptions` | Chrome-specific capabilities. [Refer to the ChromeDriver documentation](https://developer.chrome.com/docs/chromedriver/capabilities#recognized_capabilities) for more details. |
+### browserName
 
-## Microsoft-Specific
+| Name | Type | Default |
+| -- | -- | -- |
+| `browserName` | `string` | Not specified |
 
-| Capability | Description |
-| --- | --- |
-| `ms:edgeOptions` | Edge-specific capabilities. [Refer to the EdgeDriver documentation](https://learn.microsoft.com/en-us/microsoft-edge/webdriver/capabilities-edge-options#recognized-capabilities) for more details. |
+Must be set to `MicrosoftEdge` (case-sensitive) if automating MS Edge. Can be left unset for other
+Chromium-based browsers.
+
+## General
+
+### automationName
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:automationName` | `string` | Not specified |
+
+Specifies the Appium driver to use. Must be set to `Chromium` (case-insensitive)
+
+## Google
+
+### chromeOptions
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `goog:chromeOptions` | `Record<string, any>` | Not specified |
+
+Chrome-specific capabilities. [Refer to the ChromeDriver documentation](https://developer.chrome.com/docs/chromedriver/capabilities#recognized_capabilities)
+for more details.
+
+## Microsoft
+
+### edgeOptions
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `ms:edgeOptions` | `Record<string, any>` | Not specified |
+
+Microsoft Edge-specific capabilities. [Refer to the EdgeDriver documentation](https://learn.microsoft.com/en-us/microsoft-edge/webdriver/capabilities-edge-options#recognized-capabilities)
+for more details.
+
+## Chromedriver / Edgedriver
+
+### chromedriverPort
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:chromedriverPort` | `number` | `9515` |
+
+The port to use for starting `chromedriver`/`msedgedriver`
+
+### executable
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:executable` | `string` | Not specified |
+
+Custom path to a `chromedriver`/`msedgedriver` binary
+
+### executableDir
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:executableDir` | `string` | Not specified |
+
+Custom path to a directory containing `chromedriver`/`msedgedriver` binaries
+
+### verbose
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:verbose` | `boolean` | `false` |
+
+Whether to enable verbose logging. Maps to the `--verbose` flag of the `chromedriver`/`msedgedriver`
+binary.
+
+### logPath
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:logPath` | `string` | Not specified |
+
+If specified, log output will be written to the file on this path, instead of the default logger.
+Maps to the `--log-path` flag of the `chromedriver`/`msedgedriver` binary.
+
+### disableBuildCheck
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:disableBuildCheck` | `boolean` | `false` |
+
+Whether to disable the check that requires `chromedriver`/`msedgedriver` and the browser executable
+to have matching versions. Maps to the `--disable-build-check` flag of the
+`chromedriver`/`msedgedriver` binary.
+
+### autodownloadEnabled
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:autodownloadEnabled` | `boolean` | `true` |
+
+Whether to automatically download a compatible `chromedriver`/`msedgedriver` when starting a new
+session
+
+### useSystemExecutable
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:useSystemExecutable` | `boolean` | `false` |
+
+Whether to use the `chromedriver` binary bundled with Chromium driver.
+
+This capability is primarily relevant for Chromium driver versions 1.3.35 or earlier, which
+automatically downloaded `chromedriver` upon installation.

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -19,7 +19,7 @@ for more information about these capabilities.
 | -- | -- | -- |
 | `platformName` | `string` | Not specified |
 
-This capability be set to `mac`, `linux` or `windows` (case-insensitive)
+This capability must be set to `mac`, `linux` or `windows` (case-insensitive)
 
 ### browserName
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -1,7 +1,4 @@
 ---
-hide:
-  - toc
-
 title: Scripts
 ---
 
@@ -30,7 +27,7 @@ appium driver run chromium install-chromedriver
 
 ##### Optional Environment Variables
 
-|<div style="width:15em">Variable</div>|<div style="width:22em">Description</div>|Default|
+|<div style="width:15em">Variable</div>|<div style="width:14em">Description</div>|Default|
 |--|--|--|
 |`CHROMEDRIVER_VERSION`|Specific version of `chromedriver` to download|Latest known good stable|
 |`CHROMEDRIVER_EXECUTABLE_DIR`|Directory where the binary should be installed|The `chromedrivers` directory under [`envPaths('appium-chromium-driver').data`](https://github.com/sindresorhus/env-paths#pathsdata)|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,8 +36,8 @@ nav:
           - reference/scripts.md
       - Session Configuration:
           - reference/capabilities.md
-          - reference/bidi.md
           - reference/endpoints.md
+          - reference/bidi.md
       - Element Management:
           - reference/locator-strategies.md
   - Guides:


### PR DESCRIPTION
This adjusts some documentation pages to match the formatting of the Mac2 driver documentation:
* Expanded format of the capabilities page
* Rename 'BiDi Events' to 'BiDi Commands and Events' and align page placement in navigation sidebar
* Add table of contents to scripts page